### PR TITLE
Document attachment widget

### DIFF
--- a/example/components/DocumentAttach.js
+++ b/example/components/DocumentAttach.js
@@ -1,0 +1,20 @@
+import PropTypes from 'prop-types'
+
+const React = require('react')
+const Widgets = require('../widgets')
+
+const DocumentAttach = ({ label }) => (
+  <div>
+    <input type='DocumentAttach' /> { label }
+  </div>
+)
+
+DocumentAttach.propTypes = {
+  label: PropTypes.string
+}
+
+DocumentAttach.Widgets = {
+  label: Widgets.DocumentAttachWidget
+}
+
+module.exports = DocumentAttach

--- a/example/components/DocumentAttach.js
+++ b/example/components/DocumentAttach.js
@@ -4,8 +4,8 @@ const React = require('react')
 const Widgets = require('../widgets')
 
 const DocumentAttach = ({ label }) => (
-  <div>
-    <input type='DocumentAttach' /> { label }
+  <div class='download-box'>
+    Click to download: { label.name }
   </div>
 )
 

--- a/example/components/Section.js
+++ b/example/components/Section.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 const React = require('react')
 const Form = require('./Form')
 const Description = require('./Description')
+const DocumentAttach = require('./DocumentAttach')
 const Widgets = require('../widgets')
 const { TreeEditor, withProps } = require('../../')
 
@@ -21,7 +22,7 @@ Section.propTypes = {
 
 Section.Widgets = {
   title: Widgets.InputWidget,
-  children: withProps(TreeEditor, { types: { Section, Form, Description } })
+  children: withProps(TreeEditor, { types: { Section, Form, Description, DocumentAttach } })
 }
 
 Section.Title = Title

--- a/example/components/index.js
+++ b/example/components/index.js
@@ -5,5 +5,6 @@ module.exports = {
   Checkbox: require('./Checkbox'),
   TextArea: require('./TextArea'),
   Dropdown: require('./Dropdown'),
-  Description: require('./Description')
+  Description: require('./Description'),
+  DocumentAttach: require('./DocumentAttach')
 }

--- a/example/style.css
+++ b/example/style.css
@@ -64,3 +64,9 @@ main > .tree-editor, .preview {
 .public-DraftEditorPlaceholder-inner, .public-DraftStyleDefault-block {
   padding-top: 20px;
 }
+
+.download-box {
+  border: 1px solid black;
+  padding: 10px;
+  display: inline-block;
+}

--- a/example/widgets/DocumentAttachWidget.js
+++ b/example/widgets/DocumentAttachWidget.js
@@ -6,40 +6,22 @@ class DocumentAttachWidget extends React.Component {
     this.state = {
       file: null
     }
-    this.onFormSubmit = this.onFormSubmit.bind(this)
-    this.onChange = this.onChange.bind(this)
-    this.fileUpload = this.fileUpload.bind(this)
+    this.handleChange = this.handleChange.bind(this)
   }
-  onFormSubmit (e) {
-    e.preventDefault() // Stop form submit
-    this.fileUpload(this.state.file).then((response) => {
-      console.log('res[ data', response.data)
+  getState () {
+    return this.state.file
+  }
+  handleChange (event) {
+    this.setState({ file: event.target.files[0] }, function () {
+      if (this.props.onChange) {
+        this.props.onChange(this.getState())
+      }
     })
   }
-  onChange (e) {
-    this.setState({ file: e.target.files[0] })
-  }
-  fileUpload (file) {
-    // const url = 'http://example.com/file-upload'
-    debugger;
-    console.log('file ', file.value)
-    const formData = new FormData()
-    formData.append('file', file)
-    console.log('formData ', formData)
-    // const config = {
-    //   headers: {
-    //     'content-type': 'multipart/form-data'
-    //   }
-    // }
-    // return  post(url, formData,config)
-  }
-
   render () {
     return (
       <form onSubmit={this.onFormSubmit}>
-        <h1>File Upload</h1>
-        <input type='file' onChange={this.onChange} />
-        <button type='submit'>Upload</button>
+        <input type='file' onChange={this.handleChange} />
       </form>
     )
   }

--- a/example/widgets/DocumentAttachWidget.js
+++ b/example/widgets/DocumentAttachWidget.js
@@ -1,0 +1,48 @@
+import React from 'react'
+
+class DocumentAttachWidget extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      file: null
+    }
+    this.onFormSubmit = this.onFormSubmit.bind(this)
+    this.onChange = this.onChange.bind(this)
+    this.fileUpload = this.fileUpload.bind(this)
+  }
+  onFormSubmit (e) {
+    e.preventDefault() // Stop form submit
+    this.fileUpload(this.state.file).then((response) => {
+      console.log('res[ data', response.data)
+    })
+  }
+  onChange (e) {
+    this.setState({ file: e.target.files[0] })
+  }
+  fileUpload (file) {
+    // const url = 'http://example.com/file-upload'
+    debugger;
+    console.log('file ', file.value)
+    const formData = new FormData()
+    formData.append('file', file)
+    console.log('formData ', formData)
+    // const config = {
+    //   headers: {
+    //     'content-type': 'multipart/form-data'
+    //   }
+    // }
+    // return  post(url, formData,config)
+  }
+
+  render () {
+    return (
+      <form onSubmit={this.onFormSubmit}>
+        <h1>File Upload</h1>
+        <input type='file' onChange={this.onChange} />
+        <button type='submit'>Upload</button>
+      </form>
+    )
+  }
+}
+
+export default DocumentAttachWidget

--- a/example/widgets/index.js
+++ b/example/widgets/index.js
@@ -2,5 +2,6 @@ module.exports = {
   TreeEditor: require('../../'),
   InputWidget: require('./InputWidget').default,
   TextAreaWidget: require('./TextAreaWidget').default,
-  WYSIWYGWidget: require('./WYSIWYGWidget').default
+  WYSIWYGWidget: require('./WYSIWYGWidget').default,
+  DocumentAttachWidget: require('./DocumentAttachWidget').default
 }


### PR DESCRIPTION
Here's the current behavior. My proposal is that we should iterate through all the forms in the DOM when they click "export" and that that should formally upload all the files to the DB. Initially I wanted an upload button but that honestly made very little sense as a UX because then you could forget to hit the upload button or click it too much and we'd have irrelevant files in the DB

<img width="1396" alt="screen shot 2018-12-26 at 4 04 40 pm" src="https://user-images.githubusercontent.com/3953117/50457235-1f4d1d00-0928-11e9-8434-d186e7b61eb2.png">
